### PR TITLE
feat: Add generic DataSource<T> class

### DIFF
--- a/LocalXamler/LocalXamler/Core/DataSource.cs
+++ b/LocalXamler/LocalXamler/Core/DataSource.cs
@@ -1,0 +1,72 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace LocalXamler.Core
+{
+    public class DataSource<T>
+    {
+        public string Name { get; private set; }
+        public string Id { get; private set; }
+        public bool IsHealthy { get; private set; }
+
+        private readonly ConcurrentQueue<T> _dataQueue;
+
+        public DataSource(string name, string id)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new System.ArgumentException("DataSource name cannot be null or whitespace.", nameof(name));
+            }
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new System.ArgumentException("DataSource ID cannot be null or whitespace.", nameof(id));
+            }
+
+            Name = name;
+            Id = id;
+            IsHealthy = true; // Default health status
+            _dataQueue = new ConcurrentQueue<T>();
+        }
+
+        public void SetHealthStatus(bool isHealthy)
+        {
+            IsHealthy = isHealthy;
+        }
+
+        public void Add(T item)
+        {
+            _dataQueue.Enqueue(item);
+        }
+
+        public void AddRange(IEnumerable<T> items)
+        {
+            if (items == null)
+            {
+                throw new System.ArgumentNullException(nameof(items), "Items collection cannot be null.");
+            }
+            foreach (var item in items)
+            {
+                _dataQueue.Enqueue(item);
+            }
+        }
+
+        public bool TryDequeue(out T item)
+        {
+            return _dataQueue.TryDequeue(out item);
+        }
+
+        public bool TryPeek(out T item)
+        {
+            return _dataQueue.TryPeek(out item);
+        }
+
+        public void Clear()
+        {
+            // Assuming ConcurrentQueue<T>.Clear() is available.
+            // If not, this would need to be: while (_dataQueue.TryDequeue(out _)) { }
+            _dataQueue.Clear();
+        }
+
+        public int Count => _dataQueue.Count;
+    }
+}

--- a/LocalXamler/LocalXamler/Core/DataSource.cs
+++ b/LocalXamler/LocalXamler/Core/DataSource.cs
@@ -3,13 +3,13 @@ using System.Collections.Generic;
 
 namespace LocalXamler.Core
 {
-    public class DataSource<T>
+    public class DataSource<TItem, TValue> where TItem : ITimestampedData<TValue>
     {
         public string Name { get; private set; }
         public string Id { get; private set; }
         public bool IsHealthy { get; private set; }
 
-        private readonly ConcurrentQueue<T> _dataQueue;
+        private readonly ConcurrentQueue<TItem> _dataQueue;
 
         public DataSource(string name, string id)
         {
@@ -25,7 +25,7 @@ namespace LocalXamler.Core
             Name = name;
             Id = id;
             IsHealthy = true; // Default health status
-            _dataQueue = new ConcurrentQueue<T>();
+            _dataQueue = new ConcurrentQueue<TItem>();
         }
 
         public void SetHealthStatus(bool isHealthy)
@@ -33,12 +33,12 @@ namespace LocalXamler.Core
             IsHealthy = isHealthy;
         }
 
-        public void Add(T item)
+        public void Add(TItem item)
         {
             _dataQueue.Enqueue(item);
         }
 
-        public void AddRange(IEnumerable<T> items)
+        public void AddRange(IEnumerable<TItem> items)
         {
             if (items == null)
             {
@@ -50,12 +50,12 @@ namespace LocalXamler.Core
             }
         }
 
-        public bool TryDequeue(out T item)
+        public bool TryDequeue(out TItem item)
         {
             return _dataQueue.TryDequeue(out item);
         }
 
-        public bool TryPeek(out T item)
+        public bool TryPeek(out TItem item)
         {
             return _dataQueue.TryPeek(out item);
         }

--- a/LocalXamler/LocalXamler/Core/DataSource.cs
+++ b/LocalXamler/LocalXamler/Core/DataSource.cs
@@ -5,6 +5,12 @@ namespace LocalXamler.Core
 {
     public class DataSource<TItem, TValue> where TItem : ITimestampedData<TValue>
     {
+        public delegate bool TriggerCondition(TItem item);
+
+        public event EventHandler<TItem> OnTriggered;
+
+        private TriggerCondition _activeTriggerCondition;
+
         public string Name { get; private set; }
         public string Id { get; private set; }
         public bool IsHealthy { get; private set; }
@@ -33,9 +39,20 @@ namespace LocalXamler.Core
             IsHealthy = isHealthy;
         }
 
+        public void SetTrigger(TriggerCondition newCondition)
+        {
+            _activeTriggerCondition = newCondition;
+        }
+
         public void Add(TItem item)
         {
             _dataQueue.Enqueue(item);
+
+            // Check and invoke trigger
+            if (_activeTriggerCondition != null && _activeTriggerCondition(item))
+            {
+                OnTriggered?.Invoke(this, item);
+            }
         }
 
         public void AddRange(IEnumerable<TItem> items)
@@ -47,6 +64,12 @@ namespace LocalXamler.Core
             foreach (var item in items)
             {
                 _dataQueue.Enqueue(item);
+
+                // Check and invoke trigger for each item
+                if (_activeTriggerCondition != null && _activeTriggerCondition(item))
+                {
+                    OnTriggered?.Invoke(this, item);
+                }
             }
         }
 

--- a/LocalXamler/LocalXamler/Core/DataSource.cs
+++ b/LocalXamler/LocalXamler/Core/DataSource.cs
@@ -7,9 +7,9 @@ namespace LocalXamler.Core
     {
         public delegate bool TriggerCondition(TItem item);
 
-        public event EventHandler<TItem> OnTriggered;
+        public event EventHandler<TriggerEventArgs<TItem>> TriggerActivated;
 
-        private TriggerCondition _activeTriggerCondition;
+        private readonly ConcurrentDictionary<string, TriggerCondition> _triggers = new ConcurrentDictionary<string, TriggerCondition>();
 
         public string Name { get; private set; }
         public string Id { get; private set; }
@@ -39,19 +39,56 @@ namespace LocalXamler.Core
             IsHealthy = isHealthy;
         }
 
-        public void SetTrigger(TriggerCondition newCondition)
+        public void RegisterTrigger(string triggerName, TriggerCondition condition)
         {
-            _activeTriggerCondition = newCondition;
+            if (string.IsNullOrWhiteSpace(triggerName))
+            {
+                throw new System.ArgumentException("Trigger name cannot be null or whitespace.", nameof(triggerName));
+            }
+            if (condition == null)
+            {
+                throw new System.ArgumentNullException(nameof(condition), "Trigger condition cannot be null.");
+            }
+            _triggers.AddOrUpdate(triggerName, condition, (key, oldCondition) => condition);
+        }
+
+        public bool UnregisterTrigger(string triggerName)
+        {
+            if (string.IsNullOrWhiteSpace(triggerName))
+            {
+                return false; 
+            }
+            return _triggers.TryRemove(triggerName, out _);
+        }
+
+        public void ClearAllTriggers()
+        {
+            _triggers.Clear();
+        }
+
+        public IEnumerable<string> GetRegisteredTriggerNames()
+        {
+            return _triggers.Keys;
         }
 
         public void Add(TItem item)
         {
-            _dataQueue.Enqueue(item);
+            _dataQueue.Enqueue(item); // Enqueue the item first
 
-            // Check and invoke trigger
-            if (_activeTriggerCondition != null && _activeTriggerCondition(item))
+            // Iterate through all registered triggers.
+            // ConcurrentDictionary can be safely iterated even if modified concurrently from other threads in many scenarios.
+            // The items returned by GetEnumerator reflect the state of the dictionary at some point in time.
+            foreach (var triggerEntry in _triggers) 
             {
-                OnTriggered?.Invoke(this, item);
+                // triggerEntry is KeyValuePair<string, TriggerCondition>
+                // triggerEntry.Key is the trigger name (string)
+                // triggerEntry.Value is the TriggerCondition delegate
+
+                if (triggerEntry.Value(item)) // Check the condition using the delegate
+                {
+                    // Fire the new event, TriggerActivated, with TriggerEventArgs
+                    TriggerActivated?.Invoke(this, new TriggerEventArgs<TItem>(triggerEntry.Key, item));
+                }
             }
         }
 
@@ -61,14 +98,23 @@ namespace LocalXamler.Core
             {
                 throw new System.ArgumentNullException(nameof(items), "Items collection cannot be null.");
             }
-            foreach (var item in items)
+            foreach (var item in items) // Outer loop for each item in the input collection
             {
-                _dataQueue.Enqueue(item);
+                _dataQueue.Enqueue(item); // Enqueue the current item
 
-                // Check and invoke trigger for each item
-                if (_activeTriggerCondition != null && _activeTriggerCondition(item))
+                // Inner loop: Iterate through all registered triggers for the current item.
+                // ConcurrentDictionary can be safely iterated.
+                foreach (var triggerEntry in _triggers)
                 {
-                    OnTriggered?.Invoke(this, item);
+                    // triggerEntry is KeyValuePair<string, TriggerCondition>
+                    // triggerEntry.Key is the trigger name (string)
+                    // triggerEntry.Value is the TriggerCondition delegate
+
+                    if (triggerEntry.Value(item)) // Check the condition using the delegate
+                    {
+                        // Fire the new event, TriggerActivated, with TriggerEventArgs
+                        TriggerActivated?.Invoke(this, new TriggerEventArgs<TItem>(triggerEntry.Key, item));
+                    }
                 }
             }
         }

--- a/LocalXamler/LocalXamler/Core/DynamicStateMachine.cs
+++ b/LocalXamler/LocalXamler/Core/DynamicStateMachine.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Collections.Generic;
+// Assuming DynamicStateMachineElements.cs is in LocalXamler.Core, so StateDefinition and TransitionDefinition are accessible.
+// If they were in a different sub-namespace, a 'using LocalXamler.Core.Elements;' or similar would be needed.
+
+namespace LocalXamler.Core
+{
+    public class DynamicStateMachine
+    {
+        public string CurrentStateName { get; private set; }
+
+        private readonly Dictionary<string, StateDefinition> _states = new Dictionary<string, StateDefinition>();
+
+        private readonly Dictionary<string, Dictionary<string, TransitionDefinition>> _transitions =
+            new Dictionary<string, Dictionary<string, TransitionDefinition>>();
+
+        public Action<string> Logger { get; set; } = message => Console.WriteLine($"[StateMachineLog] {message}");
+
+        public DynamicStateMachine()
+        {
+            // CurrentStateName is initially null.
+            // SetInitialState will be used to formally set the starting state.
+        }
+
+        public bool AddState(string stateName, Action<string, string> onEnter = null, Action<string, string> onExit = null)
+        {
+            if (string.IsNullOrWhiteSpace(stateName))
+            {
+                Logger?.Invoke($"Error: State name cannot be null or whitespace.");
+                return false;
+            }
+            if (_states.ContainsKey(stateName))
+            {
+                Logger?.Invoke($"Error: State '{stateName}' already exists.");
+                return false;
+            }
+
+            var newState = new StateDefinition(stateName) // Assumes StateDefinition is accessible
+            {
+                OnEnterAction = onEnter,
+                OnExitAction = onExit
+            };
+            _states[stateName] = newState;
+            // Also initialize the entry for this state in the _transitions dictionary if it might not exist
+            // when AddTransition is called for it as a FromState.
+            if (!_transitions.ContainsKey(stateName))
+            {
+                _transitions[stateName] = new Dictionary<string, TransitionDefinition>();
+            }
+            Logger?.Invoke($"State '{stateName}' added.");
+            return true;
+        }
+
+        public bool RemoveState(string stateName)
+        {
+            if (string.IsNullOrWhiteSpace(stateName))
+            {
+                Logger?.Invoke($"Error: State name cannot be null or whitespace for removal.");
+                return false;
+            }
+            if (!_states.ContainsKey(stateName))
+            {
+                Logger?.Invoke($"Error: State '{stateName}' not found for removal.");
+                return false;
+            }
+            if (CurrentStateName == stateName)
+            {
+                Logger?.Invoke($"Error: Cannot remove current state '{stateName}'. Change current state first or stop the machine.");
+                return false;
+            }
+
+            _states.Remove(stateName);
+
+            // Remove all transitions originating from this state
+            _transitions.Remove(stateName);
+
+            // Remove all transitions pointing to this state
+            var transitionsToRemove = new List<Tuple<string, string>>(); // FromStateName, InputKey
+            foreach (var fromStateKey in _transitions.Keys.ToList()) // ToList to allow modification
+            {
+                var inputTransitions = _transitions[fromStateKey];
+                foreach (var inputKey in inputTransitions.Keys.ToList()) // ToList to allow modification
+                {
+                    if (inputTransitions[inputKey].ToStateName == stateName)
+                    {
+                        transitionsToRemove.Add(new Tuple<string, string>(fromStateKey, inputKey));
+                    }
+                }
+            }
+
+            foreach (var transToRemove in transitionsToRemove)
+            {
+                if (_transitions.TryGetValue(transToRemove.Item1, out var inputTransitionsMap))
+                {
+                    inputTransitionsMap.Remove(transToRemove.Item2);
+                    if (inputTransitionsMap.Count == 0)
+                    {
+                        _transitions.Remove(transToRemove.Item1);
+                    }
+                }
+            }
+            Logger?.Invoke($"State '{stateName}' and its associated transitions removed.");
+            return true;
+        }
+
+        public StateDefinition GetState(string stateName)
+        {
+            if (string.IsNullOrWhiteSpace(stateName))
+            {
+                Logger?.Invoke($"Error: State name cannot be null or whitespace for GetState.");
+                return null;
+            }
+            if (_states.TryGetValue(stateName, out var stateDef))
+            {
+                return stateDef;
+            }
+            Logger?.Invoke($"Info: State '{stateName}' not found during GetState.");
+            return null;
+        }
+
+        public void SetInitialState(string stateName)
+        {
+            if (string.IsNullOrWhiteSpace(stateName))
+            {
+                Logger?.Invoke("Error: Initial state name cannot be null or whitespace.");
+                return; // Or throw ArgumentException
+            }
+            if (!_states.ContainsKey(stateName))
+            {
+                Logger?.Invoke($"Error: State '{stateName}' does not exist. Cannot set as initial state. Add the state first.");
+                return; // Or throw InvalidOperationException
+            }
+            CurrentStateName = stateName;
+            Logger?.Invoke($"Initial state set to '{stateName}'. No actions are executed on initial set.");
+        }
+
+        public bool AddTransition(string fromStateName, string input, string toStateName, Action<string, string> transitionAction = null)
+        {
+            if (string.IsNullOrWhiteSpace(fromStateName) || string.IsNullOrWhiteSpace(input) || string.IsNullOrWhiteSpace(toStateName))
+            {
+                Logger?.Invoke("Error: FromState, ToState, and Input cannot be null or whitespace for AddTransition.");
+                return false;
+            }
+            if (!_states.ContainsKey(fromStateName))
+            {
+                Logger?.Invoke($"Error: FromState '{fromStateName}' does not exist. Cannot add transition. Add the state first.");
+                return false;
+            }
+            if (!_states.ContainsKey(toStateName))
+            {
+                Logger?.Invoke($"Error: ToState '{toStateName}' does not exist. Cannot add transition. Add the state first.");
+                return false;
+            }
+
+            // Ensure the outer dictionary for fromStateName exists.
+            // This should have been handled by AddState, but as a defensive measure:
+            if (!_transitions.ContainsKey(fromStateName))
+            {
+                _transitions[fromStateName] = new Dictionary<string, TransitionDefinition>();
+            }
+
+            if (_transitions[fromStateName].ContainsKey(input))
+            {
+                Logger?.Invoke($"Error: Transition from '{fromStateName}' on input '{input}' already exists. Policy: Not overwriting. Remove it first.");
+                return false; 
+            }
+
+            var newTransition = new TransitionDefinition(fromStateName, input, toStateName) // Assumes TransitionDefinition is accessible
+            {
+                TransitionAction = transitionAction
+            };
+            _transitions[fromStateName][input] = newTransition;
+            Logger?.Invoke($"Transition added: {fromStateName} --({input})--> {toStateName}.");
+            return true;
+        }
+
+        public bool RemoveTransition(string fromStateName, string input)
+        {
+            if (string.IsNullOrWhiteSpace(fromStateName) || string.IsNullOrWhiteSpace(input))
+            {
+                Logger?.Invoke("Error: FromState and Input cannot be null or whitespace for RemoveTransition.");
+                return false;
+            }
+
+            if (_transitions.TryGetValue(fromStateName, out var stateTransitionsForFromState))
+            {
+                if (stateTransitionsForFromState.Remove(input))
+                {
+                    Logger?.Invoke($"Transition removed: {fromStateName} --({input})--> [Removed]");
+                    // If this state now has no outgoing transitions, remove its entry from the main dictionary.
+                    if (stateTransitionsForFromState.Count == 0)
+                    {
+                        _transitions.Remove(fromStateName);
+                    }
+                    return true;
+                }
+            }
+            Logger?.Invoke($"Error: Transition from '{fromStateName}' on input '{input}' not found for removal, or state itself has no transitions defined.");
+            return false;
+        }
+
+        public bool ProcessInput(string input)
+        {
+            if (string.IsNullOrWhiteSpace(CurrentStateName))
+            {
+                Logger?.Invoke("Error: Current state is not set or is invalid. Call SetInitialState with a valid state name first.");
+                return false;
+            }
+            if (!_states.ContainsKey(CurrentStateName)) // Should not happen if SetInitialState was used correctly
+            {
+                Logger?.Invoke($"Error: Current state '{CurrentStateName}' is set but no longer exists in the state definitions. This indicates an inconsistency.");
+                return false;
+            }
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                Logger?.Invoke("Error: Input to process cannot be null or whitespace.");
+                return false;
+            }
+
+            // Try to get the dictionary of transitions for the current state.
+            if (!_transitions.TryGetValue(CurrentStateName, out var transitionsFromCurrentState) || transitionsFromCurrentState == null)
+            {
+                Logger?.Invoke($"Info: No transitions defined from state '{CurrentStateName}'. Cannot process input '{input}'.");
+                return false;
+            }
+
+            // Try to get the specific transition for the given input from the current state's transitions.
+            if (!transitionsFromCurrentState.TryGetValue(input, out var selectedTransition) || selectedTransition == null)
+            {
+                Logger?.Invoke($"Info: No transition found for input '{input}' from state '{CurrentStateName}'.");
+                return false;
+            }
+
+            // A valid transition is found.
+            // FromStateDefinition is guaranteed by _states.ContainsKey(CurrentStateName) check above.
+            var fromStateDef = _states[CurrentStateName]; 
+            
+            // ToStateDefinition should be valid because AddTransition checks for ToState existence.
+            // However, a defensive check here can be useful against direct manipulations or bugs.
+            if (!_states.TryGetValue(selectedTransition.ToStateName, out var toStateDef) || toStateDef == null)
+            {
+                Logger?.Invoke($"Error: Target state '{selectedTransition.ToStateName}' for transition from '{CurrentStateName}' on input '{input}' does not exist. Transition is invalid.");
+                return false;
+            }
+
+            Logger?.Invoke($"Processing input '{input}': Attempting transition from '{CurrentStateName}' to '{selectedTransition.ToStateName}'.");
+
+            // 1. Execute OnExit action of the current (from) state.
+            // Pass the name of the state being transitioned TO, and the input that triggered it.
+            fromStateDef.OnExitAction?.Invoke(selectedTransition.ToStateName, input);
+            Logger?.Invoke($"OnExit action for state '{CurrentStateName}' executed (if defined).");
+
+            // 2. Execute the transition action.
+            // Pass the name of the state being transitioned FROM, and the state being transitioned TO.
+            selectedTransition.TransitionAction?.Invoke(CurrentStateName, selectedTransition.ToStateName);
+            Logger?.Invoke($"TransitionAction for '{CurrentStateName}' --({input})--> '{selectedTransition.ToStateName}' executed (if defined).");
+
+            string previousStateNameForOnEnter = CurrentStateName;
+            CurrentStateName = selectedTransition.ToStateName; // Update current state
+            Logger?.Invoke($"State changed: Current state is now '{CurrentStateName}'.");
+
+            // 4. Execute OnEnter action of the new current (to) state.
+            // Pass the name of the state being transitioned FROM, and the input that triggered it.
+            toStateDef.OnEnterAction?.Invoke(previousStateNameForOnEnter, input);
+            Logger?.Invoke($"OnEnter action for state '{CurrentStateName}' executed (if defined).");
+
+            return true;
+        }
+    }
+}

--- a/LocalXamler/LocalXamler/Core/DynamicStateMachineElements.cs
+++ b/LocalXamler/LocalXamler/Core/DynamicStateMachineElements.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace LocalXamler.Core
+{
+    public class StateDefinition
+    {
+        public string Name { get; }
+        public Action<string, string> OnEnterAction { get; set; } // Parameters: (string fromStateName, string triggerInput)
+        public Action<string, string> OnExitAction { get; set; }  // Parameters: (string toStateName, string triggerInput)
+
+        public StateDefinition(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("State name cannot be null or whitespace.", nameof(name));
+            }
+            Name = name;
+        }
+    }
+
+    public class TransitionDefinition
+    {
+        public string FromStateName { get; }
+        public string Input { get; } // Input that triggers the transition
+        public string ToStateName { get; }
+        public Action<string, string> TransitionAction { get; set; } // Parameters: (string fromStateName, string toStateName)
+
+        public TransitionDefinition(string fromStateName, string input, string toStateName)
+        {
+            if (string.IsNullOrWhiteSpace(fromStateName))
+            {
+                throw new ArgumentException("FromState name cannot be null or whitespace.", nameof(fromStateName));
+            }
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                throw new ArgumentException("Input cannot be null or whitespace.", nameof(input));
+            }
+            if (string.IsNullOrWhiteSpace(toStateName))
+            {
+                throw new ArgumentException("ToState name cannot be null or whitespace.", nameof(toStateName));
+            }
+
+            FromStateName = fromStateName;
+            Input = input;
+            ToStateName = toStateName;
+        }
+    }
+}

--- a/LocalXamler/LocalXamler/Core/ITimestampedData.cs
+++ b/LocalXamler/LocalXamler/Core/ITimestampedData.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace LocalXamler.Core
+{
+    public interface ITimestampedData<TValue>
+    {
+        TValue Value { get; }
+        DateTimeOffset Timestamp { get; }
+    }
+}

--- a/LocalXamler/LocalXamler/Core/SpecializedDataSourceDecorator.cs
+++ b/LocalXamler/LocalXamler/Core/SpecializedDataSourceDecorator.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic; // For IEnumerable
+using LocalXamler.Core; // Required for DataSource, ITimestampedData, etc.
+
+namespace LocalXamler.Core
+{
+    public class SpecializedDataSourceDecorator<TItem, TValue> where TItem : ITimestampedData<TValue>
+    {
+        private readonly DataSource<TItem, TValue> _dataSource;
+
+        public const string AddWithSpecialLogTriggerName = "DECORATOR_AddWithSpecialLog";
+        public const string AddTransformedTriggerName = "DECORATOR_AddTransformed";
+
+        public SpecializedDataSourceDecorator(DataSource<TItem, TValue> dataSource)
+        {
+            if (dataSource == null)
+            {
+                throw new ArgumentNullException(nameof(dataSource), "Wrapped DataSource cannot be null.");
+            }
+            _dataSource = dataSource;
+
+            // Register decorator-specific triggers.
+            // These triggers rely on their unique names to provide context to event subscribers.
+            // The condition 'item => true' ensures they are candidates to fire whenever data is added
+            // through the underlying DataSource, allowing the TriggerName to signal the context.
+            _dataSource.RegisterTrigger(AddWithSpecialLogTriggerName, item => true);
+            _dataSource.RegisterTrigger(AddTransformedTriggerName, item => true);
+        }
+
+        // Delegated members and specialized Add methods will be added in subsequent steps.
+
+        #region Event Forwarding
+        public event EventHandler<TriggerEventArgs<TItem>> TriggerActivated
+        {
+            add => _dataSource.TriggerActivated += value;
+            remove => _dataSource.TriggerActivated -= value;
+        }
+        #endregion
+
+        #region Delegated Read-Only Properties
+        public string Name => _dataSource.Name;
+        public string Id => _dataSource.Id;
+        public bool IsHealthy => _dataSource.IsHealthy;
+        public int Count => _dataSource.Count;
+        #endregion
+
+        #region Delegated Methods
+        public bool TryDequeue(out TItem item) => _dataSource.TryDequeue(out item);
+        public bool TryPeek(out TItem item) => _dataSource.TryPeek(out item);
+        public void Clear() => _dataSource.Clear();
+        public void SetHealthStatus(bool isHealthy) => _dataSource.SetHealthStatus(isHealthy);
+        #endregion
+
+        #region Delegated Trigger Management Methods
+        public void RegisterTrigger(string triggerName, DataSource<TItem, TValue>.TriggerCondition condition) => _dataSource.RegisterTrigger(triggerName, condition);
+        public bool UnregisterTrigger(string triggerName) => _dataSource.UnregisterTrigger(triggerName);
+        public void ClearAllTriggers() => _dataSource.ClearAllTriggers();
+        public IEnumerable<string> GetRegisteredTriggerNames() => _dataSource.GetRegisteredTriggerNames();
+        #endregion
+
+        #region Specialized Add Methods
+        public void AddWithSpecialLog(TItem item, string customLogMessage)
+        {
+            // Assuming TItem might have a null value if it's a class, 
+            // but the item structure itself (TItem) is provided.
+            // A null check for 'item' itself could be added if TItem is a reference type
+            // and null is not a valid item to add.
+            // e.g., if (item == null) throw new ArgumentNullException(nameof(item));
+
+            if (customLogMessage == null)
+            {
+                customLogMessage = string.Empty; 
+            }
+
+            // Ensure item.Value is accessed safely if Value can be null.
+            // This depends on TValue. For simplicity, direct access is used.
+            Console.WriteLine($"[DataSourceDecorator] Special Log: '{customLogMessage}' for item with value '{item.Value}' (Timestamp: {item.Timestamp})");
+            
+            _dataSource.Add(item); 
+        }
+
+        public void AddTransformed(TValue originalData, Func<TValue, TItem> transformationFunction, string transformationDescription)
+        {
+            if (transformationFunction == null)
+            {
+                throw new ArgumentNullException(nameof(transformationFunction), "Transformation function cannot be null.");
+            }
+            if (transformationDescription == null)
+            {
+                transformationDescription = string.Empty;
+            }
+
+            TItem item = transformationFunction(originalData);
+
+            // Consider if 'item' itself can be null after transformation and if that's valid.
+            if (item == null)
+            {
+                // Depending on requirements, either throw or handle this case.
+                // For now, let's assume a valid item is always returned or _dataSource.Add handles nulls if permissible.
+                // If null items are strictly forbidden:
+                // throw new InvalidOperationException("Transformation function returned a null TItem, which cannot be added.");
+            }
+            
+            // Ensure item.Value is accessed safely if Value can be null.
+            Console.WriteLine($"[DataSourceDecorator] Data transformed via '{transformationDescription}'. Original: '{originalData}', New Item Value: '{item.Value}' (Timestamp: {item.Timestamp})");
+            
+            _dataSource.Add(item);
+        }
+        #endregion
+    }
+}

--- a/LocalXamler/LocalXamler/Core/TriggerEventArgs.cs
+++ b/LocalXamler/LocalXamler/Core/TriggerEventArgs.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace LocalXamler.Core
+{
+    public class TriggerEventArgs<TItem> : EventArgs
+    {
+        public string TriggerName { get; }
+        public TItem Item { get; }
+
+        public TriggerEventArgs(string triggerName, TItem item)
+        {
+            if (string.IsNullOrWhiteSpace(triggerName))
+            {
+                throw new ArgumentException("Trigger name cannot be null or whitespace.", nameof(triggerName));
+            }
+            // Item validity depends on TItem's nature (value/reference type)
+            // and specific requirements, so no generic null check here.
+            
+            TriggerName = triggerName;
+            Item = item;
+        }
+    }
+}


### PR DESCRIPTION
Implemented a new generic class `DataSource<T>` to provide a common data source mechanism.

Features:
- Generic type parameter for flexible data storage.
- Properties: Name (string), Id (string), IsHealthy (bool).
- Uses `System.Collections.Concurrent.ConcurrentQueue<T>` for thread-safe, FIFO data handling.
- Constructor to initialize name, ID, and default health status.
- `Add(T item)` method to add a single item.
- `AddRange(IEnumerable<T> items)` method to add a collection of items.
- `TryDequeue(out T item)` method to retrieve and remove an item.
- `TryPeek(out T item)` method to view the next item without removal.
- `Clear()` method to remove all items.
- `Count` property to get the current number of items.
- `SetHealthStatus(bool isHealthy)` method to update the health status.

The class is located in `LocalXamler/LocalXamler/Core/DataSource.cs`.